### PR TITLE
feat: add experimental go implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,17 @@
 - [国外匿名代理](https://www.ipmart.io?source=Shironeko)
 
 ![Star History Chart](https://api.star-history.com/svg?repos=honmashironeko/ProxyCat&type=Date)
+
+## Go版本（实验性）
+
+项目新增了一个使用 Go 编写的实验性实现，支持通过 Web 界面手动检测并管理失效代理。
+
+运行方式：
+
+```
+cd go
+go run ./cmd/proxycat
+```
+
+在界面中，检测失败的代理会单独列出，可手动再次检测。如果检测通过，将其恢复到有效列表，否则继续保留在失败列表；同时也支持单独删除或一键删除所有失败代理。
+

--- a/go/cmd/proxycat/main.go
+++ b/go/cmd/proxycat/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"html/template"
+	"log"
+	"net/http"
+
+	"proxycat/proxy"
+)
+
+var (
+	tpl     = template.Must(template.ParseFiles("web/index.html"))
+	manager = proxy.NewManager(proxy.HTTPCheck)
+)
+
+func main() {
+	http.HandleFunc("/", handleIndex)
+	http.HandleFunc("/add", handleAdd)
+	http.HandleFunc("/retry", handleRetry)
+	http.HandleFunc("/delete", handleDelete)
+	http.HandleFunc("/deleteAll", handleDeleteAll)
+	log.Println("listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func handleIndex(w http.ResponseWriter, r *http.Request) {
+	data := struct {
+		Active []proxy.Proxy
+		Failed []proxy.Proxy
+	}{
+		Active: manager.Active(),
+		Failed: manager.Failed(),
+	}
+	tpl.Execute(w, data)
+}
+
+func handleAdd(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err == nil {
+		addr := r.Form.Get("address")
+		if addr != "" {
+			manager.Add(addr)
+		}
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func handleRetry(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err == nil {
+		id := r.Form.Get("id")
+		manager.Retry(id)
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func handleDelete(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err == nil {
+		id := r.Form.Get("id")
+		manager.Delete(id)
+	}
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}
+
+func handleDeleteAll(w http.ResponseWriter, r *http.Request) {
+	manager.DeleteAllFailed()
+	http.Redirect(w, r, "/", http.StatusSeeOther)
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module proxycat
+
+go 1.24.3

--- a/go/proxy/check.go
+++ b/go/proxy/check.go
@@ -1,0 +1,23 @@
+package proxy
+
+import (
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// HTTPCheck verifies a proxy by requesting example.com through it.
+func HTTPCheck(address string) bool {
+	proxyURL, err := url.Parse(address)
+	if err != nil {
+		return false
+	}
+	transport := &http.Transport{Proxy: http.ProxyURL(proxyURL)}
+	client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+	resp, err := client.Get("http://example.com")
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}

--- a/go/proxy/manager.go
+++ b/go/proxy/manager.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"sync"
+)
+
+// Proxy represents a single proxy server.
+type Proxy struct {
+	ID      string
+	Address string
+}
+
+// Manager keeps track of active and failed proxies.
+type Manager struct {
+	mu      sync.RWMutex
+	active  map[string]Proxy
+	failed  map[string]Proxy
+	checker func(string) bool
+}
+
+// NewManager creates a Manager that uses checker to verify proxies.
+func NewManager(checker func(string) bool) *Manager {
+	return &Manager{
+		active:  make(map[string]Proxy),
+		failed:  make(map[string]Proxy),
+		checker: checker,
+	}
+}
+
+// Add adds a proxy, placing it in active or failed based on checker.
+func (m *Manager) Add(address string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p := Proxy{ID: address, Address: address}
+	if m.checker(address) {
+		m.active[p.ID] = p
+	} else {
+		m.failed[p.ID] = p
+	}
+}
+
+// Active returns all active proxies.
+func (m *Manager) Active() []Proxy {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	res := make([]Proxy, 0, len(m.active))
+	for _, p := range m.active {
+		res = append(res, p)
+	}
+	return res
+}
+
+// Failed returns all failed proxies.
+func (m *Manager) Failed() []Proxy {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	res := make([]Proxy, 0, len(m.failed))
+	for _, p := range m.failed {
+		res = append(res, p)
+	}
+	return res
+}
+
+// Retry checks a failed proxy again. If successful, it moves to active.
+func (m *Manager) Retry(id string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	p, ok := m.failed[id]
+	if !ok {
+		return false
+	}
+	if m.checker(p.Address) {
+		delete(m.failed, id)
+		m.active[id] = p
+		return true
+	}
+	return false
+}
+
+// Delete removes a failed proxy by id.
+func (m *Manager) Delete(id string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.failed, id)
+}
+
+// DeleteAllFailed clears all failed proxies.
+func (m *Manager) DeleteAllFailed() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failed = make(map[string]Proxy)
+}

--- a/go/proxy/manager_test.go
+++ b/go/proxy/manager_test.go
@@ -1,0 +1,55 @@
+package proxy
+
+import "testing"
+
+func TestManagerAddAndRetry(t *testing.T) {
+	results := map[string]bool{
+		"good": true,
+		"bad":  false,
+	}
+	checker := func(addr string) bool { return results[addr] }
+
+	m := NewManager(checker)
+	m.Add("good")
+	m.Add("bad")
+
+	if len(m.Active()) != 1 {
+		t.Fatalf("expected 1 active proxy, got %d", len(m.Active()))
+	}
+	if len(m.Failed()) != 1 {
+		t.Fatalf("expected 1 failed proxy, got %d", len(m.Failed()))
+	}
+
+	results["bad"] = true
+	if !m.Retry("bad") {
+		t.Fatalf("expected retry to succeed")
+	}
+	if len(m.Failed()) != 0 {
+		t.Fatalf("expected 0 failed proxies, got %d", len(m.Failed()))
+	}
+}
+
+func TestDeleteAllFailed(t *testing.T) {
+	results := map[string]bool{
+		"bad1": false,
+		"bad2": false,
+	}
+	checker := func(addr string) bool { return results[addr] }
+
+	m := NewManager(checker)
+	m.Add("bad1")
+	m.Add("bad2")
+	if len(m.Failed()) != 2 {
+		t.Fatalf("expected 2 failed proxies, got %d", len(m.Failed()))
+	}
+
+	m.Delete("bad1")
+	if len(m.Failed()) != 1 {
+		t.Fatalf("expected 1 failed proxy, got %d", len(m.Failed()))
+	}
+
+	m.DeleteAllFailed()
+	if len(m.Failed()) != 0 {
+		t.Fatalf("expected no failed proxies after delete all")
+	}
+}

--- a/go/web/index.html
+++ b/go/web/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>ProxyCat Go</title>
+</head>
+<body>
+<h1>Add Proxy</h1>
+<form method="POST" action="/add">
+    <input name="address" placeholder="http://1.2.3.4:8080" />
+    <button type="submit">Add</button>
+</form>
+
+<h2>Active Proxies</h2>
+<ul>
+{{range .Active}}
+<li>{{.Address}}</li>
+{{else}}
+<li>None</li>
+{{end}}
+</ul>
+
+<h2>Failed Proxies</h2>
+<ul>
+{{range .Failed}}
+<li>
+    {{.Address}}
+    <form style="display:inline" method="POST" action="/retry">
+        <input type="hidden" name="id" value="{{.ID}}" />
+        <button type="submit">Manual Check</button>
+    </form>
+    <form style="display:inline" method="POST" action="/delete">
+        <input type="hidden" name="id" value="{{.ID}}" />
+        <button type="submit">Delete</button>
+    </form>
+</li>
+{{else}}
+<li>None</li>
+{{end}}
+</ul>
+<form method="POST" action="/deleteAll">
+    <button type="submit">Delete All Failed</button>
+</form>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- prototype Go rewrite with manager for active and failed proxies
- web UI to retry and remove failed proxies
- document experimental Go version and run instructions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6892aee41b2c83259accd86dd0a26ba6